### PR TITLE
Improve explanation of Turbolinks & jQuery fight

### DIFF
--- a/_posts/2016-1-27-Jquery-Turbolinks.md
+++ b/_posts/2016-1-27-Jquery-Turbolinks.md
@@ -5,7 +5,7 @@ title: Jquery-Turbolinks
 
 I had an issue with a past rails project, [Sea Dogs](https://github.com/stevenrayesky/pirate_ships_project), where on initial page load my javascript was not working. On click, I giant message was supposed to flash on the screen to let the user know that they had successfully "stalked" a boat. Unfortunately, it only worked when the page was then reloaded.
 
-As I understand it (and I am still figuring it out), turbolinks is a gem that is on by default in rails. From the turbolinks github:
+Turbolinks is a gem that is on by default in rails. From the turbolinks github:
 
 ```
 Turbolinks makes following links in your web application 
@@ -19,7 +19,7 @@ Faster pages. Pretty cool, right?
 
 Well, in my case things got a little screwy when mixed with Jquery. Let's see if I can make sense of it:
 
-On a page, I click to a link that has some jquery. It looks like this:
+On a page, I add a click handler to a link with jQuery. It looks like this:
 
 ```
 $(document).ready(function(){
@@ -29,7 +29,7 @@ $(document).ready(function(){
 });
 ```
 
-Looks ok, right? Only problem is with Turbolinks, the document is not "ready", because it is not fully loaded. Turbolinks is going around that and only replacing the body.
+Looks ok, right? Only problem is with Turbolinks, the document becomes "ready" once, at first page load. After that, Turbolinks is going around that and only replacing the body. So all of my `.boat_image` links that happen to be on the page at first load get handled the way I want. But any `.boat_image` links on follow-up pages—pages loaded with Turbolinks—never get this click handler added to them. Because `$(document).ready` only fires once, when the page first loads, not after Turbolinks swaps in new content.
 
 In order to fix this I required another gem that fixes this specific problem, [Jquery-Turbolinks](https://rubygems.org/gems/jquery-turbolinks).
 
@@ -37,13 +37,11 @@ In order to fix this I required another gem that fixes this specific problem, [J
 
 1. Put turbolinks in the Gemfile
 
-![Jquery-Turbolinks_Gemfile]
-(../../images/Jquery_Turbolinks_Gemfile.png)
+    ![Jquery-Turbolinks_Gemfile](../../images/Jquery_Turbolinks_Gemfile.png)
 
 2. In your application.js file in your Javascript folder require it. Note the order, it is relevant.
 
-![Jquery_Turbolinks_app_js]
-(../../images/Jquery_Turbolinks_app_js.png)
+    ![Jquery_Turbolinks_app_js](../../images/Jquery_Turbolinks_app_js.png)
 
 3. Finally 
 `gem install jquery-turbolinks` 


### PR DESCRIPTION
Hey Steven! Your explanation of what was going wrong seemed slightly inaccurate to me. Hopefully this clears it up for you!

Also, `jquery-turbolinks` is fine, but it's probably better-suited to help large projects with lots of existing jQuery logic to adopt Turbolinks. For a small project like this, you could get away without adding an extra dependency.

You have a couple options:

### 1. Hook into one of Turbolinks' [custom events](https://github.com/turbolinks/turbolinks-classic#events), rather than `document ready`:

``` javascript
$(document).on('page:change', function() {
	$(".boat_image").click(function(){
		$(this).siblings(".expedition_form_div").css("display", "inline");
	});
});
```

### 2. Use a global click handler

jQuery lets you "move the handler up the DOM tree":

``` javascript
$(document).ready(function() {
  $(document).on('click', '.boat_image', function() {
    $(this).siblings(".expedition_form_div").css("display", "inline");
  });
});
```

This works because the handler is attached once, to the document root, which stays around as Turbolinks swaps out all the content. In the way you have it, a separate click handler is attached to each link, and so you need to re-attach a new handler to links as they're loaded into the page with ajax.

Let me know if that makes sense!

PS: I also fixed your numbering in that list—markdown lists can be tricky!